### PR TITLE
Remove duplicate BZscrap link in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -89,7 +89,6 @@ If you are looking to find already published mods availabe for `BZ98R` and `BZCC
 We recommend you check out the links below!
 
 `Resources`
-- [BZ Scrap.org](https://bzmaps.net/)
 - [Goomba's Battlezone Maproom](https://bzmaps.net/)
 - [Battlezone 1 Utilities (GitHub)](https://github.com/BattlezoneUtilities)
 - [Battlezone II Scrap Management Guide](https://www.matesfamily.org/bz2/scrapmgmt.html)


### PR DESCRIPTION
BZ Scrap referenced incorrect link, and was duplicated.